### PR TITLE
Increase limit of generators list to 100

### DIFF
--- a/html/www/js/nrs.generators.js
+++ b/html/www/js/nrs.generators.js
@@ -69,7 +69,7 @@ var NRS = (function(NRS) {
             loadingDotsClass: "loading_dots"
         });
         var params = {
-            "limit": 10
+            "limit": 100
         };
         NRS.sendRequest("getNextBlockGenerators+", params,
             function(response) {


### PR DESCRIPTION
There isn't a pagination on the generators page. In the top generate count it shows more generators than the table below. Increasing the limit to 100 will be enough for the time being to show all generators.